### PR TITLE
Display "Resume" without accents

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       <ul class="links">
         <li><a href="mailto:fre.and.fri@gmail.com"><svg viewBox="0 0 24 24"><path d="M2 5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5zm2 .5v.4l8 5 8-5v-.4H4zm16 2.3-7.5 4.7a1 1 0 0 1-1 0L4 7.8V19h16V7.8z"/></svg>Email</a></li>
         <li><a href="https://github.com/androidfred" rel="me noopener"><svg viewBox="0 0 24 24"><path d="M12 2A10 10 0 0 0 8.8 21.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"/></svg>GitHub</a></li>
-        <li><a href="https://docs.google.com/document/d/1xKLSoiRCl5eJbUR6-seefyGJXT1H6bVE0IJQ_fLvt8Y" rel="noopener"><svg viewBox="0 0 24 24"><path d="M6 2h8l4 4v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm7 1.5V7h3.5L13 3.5zM8 12h8v1.5H8V12zm0 3.5h8V17H8v-1.5zM8 8.5h4V10H8V8.5z"/></svg>Résumé</a></li>
+        <li><a href="https://docs.google.com/document/d/1xKLSoiRCl5eJbUR6-seefyGJXT1H6bVE0IJQ_fLvt8Y" rel="noopener"><svg viewBox="0 0 24 24"><path d="M6 2h8l4 4v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm7 1.5V7h3.5L13 3.5zM8 12h8v1.5H8V12zm0 3.5h8V17H8v-1.5zM8 8.5h4V10H8V8.5z"/></svg>Resume</a></li>
       </ul>
     </header>
 


### PR DESCRIPTION
Changes the displayed word **Résumé** → **Resume** (no accents) in `index.html`.

Single-character-class change, one line, no other content touched.

## Deploy note
Merging to `develop` triggers the **Deploy to bedobi.com** GitHub Actions workflow (`.github/workflows`), which rsyncs `index.html` to the production droplet (159.203.85.176 → bedobi.com). No GitHub Pages involved. Prod reflects the change automatically once this is merged and that workflow run succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)